### PR TITLE
Fix Server Crash on Startup

### DIFF
--- a/fabric/src/main/java/com/lx862/jcm/mod/network/gui/ButterflyLightGUIPacket.java
+++ b/fabric/src/main/java/com/lx862/jcm/mod/network/gui/ButterflyLightGUIPacket.java
@@ -30,6 +30,6 @@ public class ButterflyLightGUIPacket extends PacketHandler {
 
     @Override
     public void runClient() {
-        MinecraftClient.getInstance().openScreen(new Screen(new ButterflyLightScreen(blockPos, secondsToBlink)));
+        ClientHelper.openButterflyLightScreen(blockPos, secondsToBlink);
     }
 }

--- a/fabric/src/main/java/com/lx862/jcm/mod/network/gui/ClientHelper.java
+++ b/fabric/src/main/java/com/lx862/jcm/mod/network/gui/ClientHelper.java
@@ -1,0 +1,29 @@
+package com.lx862.jcm.mod.network.gui;
+
+import com.lx862.jcm.mod.render.gui.screen.*;
+import org.mtr.mapping.holder.BlockPos;
+import org.mtr.mapping.holder.MinecraftClient;
+import org.mtr.mapping.holder.Screen;
+
+public final class ClientHelper {
+
+	public static void openButterflyLightScreen(BlockPos blockPos, int secondsToBlink) {
+		MinecraftClient.getInstance().openScreen(new Screen(new ButterflyLightScreen(blockPos, secondsToBlink)));
+	}
+
+	public static void openFareSaverGUIScreen(BlockPos blockPos, String currency, int discount) {
+		MinecraftClient.getInstance().openScreen(new Screen(new FareSaverScreen(blockPos, currency, discount)));
+	}
+
+	public static void openPIDSGUIScreen(BlockPos blockPos, String[] customMessages, boolean[] rowHidden, boolean hidePlatformNumber, String presetId) {
+		MinecraftClient.getInstance().openScreen(new Screen(new PIDSScreen(blockPos, customMessages, rowHidden, hidePlatformNumber, presetId)));
+	}
+
+	public static void openSoundLooperGUIScreen(BlockPos blockPos, BlockPos corner1, BlockPos corner2, String soundId, int soundCategory, float soundVolume, int interval, boolean needRedstone, boolean limitRange) {
+		MinecraftClient.getInstance().openScreen(new Screen(new SoundLooperScreen(blockPos, corner1, corner2, soundId, soundCategory, soundVolume, interval, needRedstone, limitRange)));
+	}
+
+	public static void openSubsidyMachineGUIScreen(BlockPos blockPos, int pricePerUse,int cooldown) {
+		MinecraftClient.getInstance().openScreen(new Screen(new SubsidyMachineScreen(blockPos, pricePerUse, cooldown)));
+	}
+}

--- a/fabric/src/main/java/com/lx862/jcm/mod/network/gui/FareSaverGUIPacket.java
+++ b/fabric/src/main/java/com/lx862/jcm/mod/network/gui/FareSaverGUIPacket.java
@@ -35,6 +35,6 @@ public class FareSaverGUIPacket extends PacketHandler {
 
     @Override
     public void runClient() {
-        MinecraftClient.getInstance().openScreen(new Screen(new FareSaverScreen(blockPos, currency, discount)));
+        ClientHelper.openFareSaverGUIScreen(blockPos, currency, discount);
     }
 }

--- a/fabric/src/main/java/com/lx862/jcm/mod/network/gui/PIDSGUIPacket.java
+++ b/fabric/src/main/java/com/lx862/jcm/mod/network/gui/PIDSGUIPacket.java
@@ -51,6 +51,6 @@ public class PIDSGUIPacket extends PacketHandler {
 
     @Override
     public void runClient() {
-        MinecraftClient.getInstance().openScreen(new Screen(new PIDSScreen(blockPos, customMessages, rowHidden, hidePlatformNumber, presetId)));
+        ClientHelper.openPIDSGUIScreen(blockPos, customMessages, rowHidden, hidePlatformNumber, presetId);
     }
 }

--- a/fabric/src/main/java/com/lx862/jcm/mod/network/gui/SoundLooperGUIPacket.java
+++ b/fabric/src/main/java/com/lx862/jcm/mod/network/gui/SoundLooperGUIPacket.java
@@ -43,7 +43,7 @@ public class SoundLooperGUIPacket extends PacketHandler {
 
     @Override
     public void runClient() {
-        MinecraftClient.getInstance().openScreen(new Screen(new SoundLooperScreen(blockPos, corner1, corner2, soundId, soundCategory, soundVolume, interval, needRedstone, limitRange)));
+        ClientHelper.openSoundLooperGUIScreen(blockPos, corner1, corner2, soundId, soundCategory, soundVolume, interval, needRedstone, limitRange);
     }
 
     @Override

--- a/fabric/src/main/java/com/lx862/jcm/mod/network/gui/SubsidyMachineGUIPacket.java
+++ b/fabric/src/main/java/com/lx862/jcm/mod/network/gui/SubsidyMachineGUIPacket.java
@@ -35,6 +35,6 @@ public class SubsidyMachineGUIPacket extends PacketHandler {
 
     @Override
     public void runClient() {
-        MinecraftClient.getInstance().openScreen(new Screen(new SubsidyMachineScreen(blockPos, pricePerUse, cooldown)));
+        ClientHelper.openSubsidyMachineGUIScreen(blockPos, pricePerUse, cooldown);
     }
 }


### PR DESCRIPTION
I noticed that the packet handlers that open a GUI call `MinecraftClient.getInstance().openScreen()` directly. Since the screen classes in the mod are directly extending the Minecraft clientside `Screen` class, this will be an issue on the dedicated server.