### PR TITLE
Reduce redundant scripted vehicle and block entity work

### DIFF
--- a/fabric/src/main/java/com/lx862/jcm/mixin/modded/mtr/MainRendererMixin.java
+++ b/fabric/src/main/java/com/lx862/jcm/mixin/modded/mtr/MainRendererMixin.java
@@ -1,8 +1,13 @@
 package com.lx862.jcm.mixin.modded.mtr;
 
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
 import com.lx862.mtrscripting.core.util.TimingJS;
+import com.lx862.mtrscripting.mod.impl.mtr.vehicle.VehicleRenderDataCache;
 import org.mtr.mapping.holder.MinecraftClient;
+import org.mtr.mapping.holder.Vector3d;
 import org.mtr.mod.render.MainRenderer;
+import org.mtr.mod.render.RenderVehicles;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
@@ -10,6 +15,16 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 @Mixin(value = MainRenderer.class, remap = false)
 public class MainRendererMixin {
+    @WrapOperation(method = "render(Lorg/mtr/mapping/mapper/GraphicsHolder;Lorg/mtr/mapping/holder/Vector3d;)V", at = @At(value = "INVOKE", target = "Lorg/mtr/mod/render/RenderVehicles;render(JLorg/mtr/mapping/holder/Vector3d;)V"))
+    private static void jsblock$cacheVehicleRenderData(long millisElapsed, Vector3d cameraShakeOffset, Operation<Void> original) {
+        VehicleRenderDataCache.startRendering();
+        try {
+            original.call(millisElapsed, cameraShakeOffset);
+        } finally {
+            VehicleRenderDataCache.finishRendering();
+        }
+    }
+
     @Inject(method = "getMillisElapsed", at = @At("RETURN"))
     private static void incrementTimer(CallbackInfoReturnable<?> ci) {
         long elapsedTime = ci.getReturnValueJ();

--- a/fabric/src/main/java/com/lx862/jcm/mixin/modded/mtr/ModelPropertiesPartMixin.java
+++ b/fabric/src/main/java/com/lx862/jcm/mixin/modded/mtr/ModelPropertiesPartMixin.java
@@ -22,7 +22,7 @@ public class ModelPropertiesPartMixin extends ModelPropertiesPartSchema {
 
     @Inject(method = "render", at = @At("HEAD"), cancellable = true)
     private void jsblock$hideDisplayParts(Identifier texture, StoredMatrixTransformations storedMatrixTransformations, VehicleExtension vehicle, int carNumber, int[] scrollingDisplayIndexTracker, int light, ObjectArrayList<ObjectDoubleImmutablePair<Box>> openDoorways, boolean fromResourcePackCreator, CallbackInfo ci) {
-        String vehicleId = vehicle.getVehicleCarsAndPositions().get(carNumber).left().getVehicleId();
+        String vehicleId = vehicle.vehicleExtraData.immutableVehicleCars.get(carNumber).getVehicleId();
         if(type == PartType.DISPLAY && MTRContentResourceManager.shouldHideDisplayParts(vehicleId)) {
             ci.cancel();
         }

--- a/fabric/src/main/java/com/lx862/jcm/mixin/modded/mtr/VehicleResourceMixin.java
+++ b/fabric/src/main/java/com/lx862/jcm/mixin/modded/mtr/VehicleResourceMixin.java
@@ -5,6 +5,7 @@ import com.lx862.mtrscripting.mod.resource.MTRContentResourceManager;
 import com.lx862.mtrscripting.mod.impl.mtr.MTRContentScripting;
 import com.lx862.mtrscripting.core.util.render.ScriptRenderManager;
 import com.lx862.mtrscripting.core.util.sound.ScriptSoundManager;
+import com.lx862.mtrscripting.mod.impl.mtr.vehicle.VehicleRenderDataCache;
 import com.lx862.mtrscripting.mod.impl.mtr.vehicle.VehicleScriptInstance;
 import com.lx862.mtrscripting.core.primitive.ScriptInstance;
 import com.lx862.mtrscripting.core.primitive.UniqueKey;
@@ -50,7 +51,7 @@ public abstract class VehicleResourceMixin {
 
         double x = 0, y = 0, z = 0;
         int total = 0;
-        ObjectArrayList<ObjectObjectImmutablePair<Vector, Vector>> bogiePoses = vehicle.getVehicleCarsAndPositions().get(carNumber).right();
+        ObjectArrayList<ObjectObjectImmutablePair<Vector, Vector>> bogiePoses = VehicleRenderDataCache.getVehicleCarsAndPositions(vehicle).get(carNumber).right();
         for(ObjectObjectImmutablePair<Vector, Vector> bogiePos : bogiePoses) {
             x += bogiePos.left().x;
             y += bogiePos.left().y;

--- a/fabric/src/main/java/com/lx862/jcm/mod/block/entity/SoundLooperBlockEntity.java
+++ b/fabric/src/main/java/com/lx862/jcm/mod/block/entity/SoundLooperBlockEntity.java
@@ -51,14 +51,16 @@ public class SoundLooperBlockEntity extends JCMBlockEntityBase {
         World world = getWorld2();
 
         if(repeatTick > 0 && !soundID.isEmpty() && world != null && !world.isClient() && JCMServerStats.getGameTick() % repeatTick == 0) {
-            boolean bl1 = world.isEmittingRedstonePower(getPos2(), Direction.NORTH);
-            boolean bl2 = world.isEmittingRedstonePower(getPos2(), Direction.EAST);
-            boolean bl3 = world.isEmittingRedstonePower(getPos2(), Direction.SOUTH);
-            boolean bl4 = world.isEmittingRedstonePower(getPos2(), Direction.WEST);
-            boolean bl5 = world.isEmittingRedstonePower(getPos2(), Direction.UP);
-            boolean bl6 = world.isEmittingRedstonePower(getPos2(), Direction.DOWN);
-            boolean emittingRedstonePower = bl1 || bl2 || bl3 || bl4 || bl5 || bl6;
-            if(needRedstone && !emittingRedstonePower) return;
+            if(needRedstone) {
+                boolean bl1 = world.isEmittingRedstonePower(getPos2(), Direction.NORTH);
+                boolean bl2 = world.isEmittingRedstonePower(getPos2(), Direction.EAST);
+                boolean bl3 = world.isEmittingRedstonePower(getPos2(), Direction.SOUTH);
+                boolean bl4 = world.isEmittingRedstonePower(getPos2(), Direction.WEST);
+                boolean bl5 = world.isEmittingRedstonePower(getPos2(), Direction.UP);
+                boolean bl6 = world.isEmittingRedstonePower(getPos2(), Direction.DOWN);
+                boolean emittingRedstonePower = bl1 || bl2 || bl3 || bl4 || bl5 || bl6;
+                if(!emittingRedstonePower) return;
+            }
 
             final SoundCategory category = SOURCE_LIST[soundCategory];
             Identifier identifier = null;

--- a/fabric/src/main/java/com/lx862/mtrscripting/mod/impl/mtr/vehicle/VehicleRenderDataCache.java
+++ b/fabric/src/main/java/com/lx862/mtrscripting/mod/impl/mtr/vehicle/VehicleRenderDataCache.java
@@ -1,0 +1,51 @@
+package com.lx862.mtrscripting.mod.impl.mtr.vehicle;
+
+import org.mtr.core.data.VehicleCar;
+import org.mtr.core.tool.Vector;
+import org.mtr.libraries.it.unimi.dsi.fastutil.objects.ObjectArrayList;
+import org.mtr.libraries.it.unimi.dsi.fastutil.objects.ObjectObjectImmutablePair;
+import org.mtr.mod.data.VehicleExtension;
+
+public final class VehicleRenderDataCache {
+    private static final Object LOCK = new Object();
+    private static Thread renderingThread;
+    private static VehicleExtension cachedVehicle;
+    private static ObjectArrayList<ObjectObjectImmutablePair<VehicleCar, ObjectArrayList<ObjectObjectImmutablePair<Vector, Vector>>>> cachedVehicleCarsAndPositions;
+
+    private VehicleRenderDataCache() {
+    }
+
+    public static void startRendering() {
+        synchronized (LOCK) {
+            renderingThread = Thread.currentThread();
+            cachedVehicle = null;
+            cachedVehicleCarsAndPositions = null;
+        }
+    }
+
+    public static ObjectArrayList<ObjectObjectImmutablePair<VehicleCar, ObjectArrayList<ObjectObjectImmutablePair<Vector, Vector>>>> getVehicleCarsAndPositions(VehicleExtension vehicle) {
+        final Thread currentThread = Thread.currentThread();
+        synchronized (LOCK) {
+            if (renderingThread == currentThread) {
+                if (cachedVehicle == vehicle && cachedVehicleCarsAndPositions != null) {
+                    return cachedVehicleCarsAndPositions;
+                }
+
+                cachedVehicleCarsAndPositions = vehicle.getVehicleCarsAndPositions();
+                cachedVehicle = vehicle;
+                return cachedVehicleCarsAndPositions;
+            }
+        }
+        return vehicle.getVehicleCarsAndPositions();
+    }
+
+    public static void finishRendering() {
+        synchronized (LOCK) {
+            if (renderingThread == Thread.currentThread()) {
+                renderingThread = null;
+                cachedVehicle = null;
+                cachedVehicleCarsAndPositions = null;
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Reuse raw full-train car and bogie positions during one `RenderVehicles.render` invocation through a chainable MixinExtras `@WrapOperation` with `try/finally` cleanup.
- Read immutable vehicle IDs directly for model-part metadata instead of calculating train positions.
- Skip six neighbor redstone-power checks when a Sound Looper does not require redstone.

## Motivation

Scripted vehicle callbacks can request the same full-train position data repeatedly, with the cost growing with train length. The invocation-scoped, identity-keyed single-entry cache lets adjacent callbacks for one vehicle reuse that calculation while preserving raw, unsmoothed position semantics. The remaining changes remove calculations whose results are not used.

The cache is owned by the rendering thread, bypassed by non-owner threads, strongly retained only for the wrapped invocation, and cleared on both normal and exceptional exits. `@WrapOperation` delegates through the original invocation and remains chainable with other wrappers.

## Verification

- Fabric 1.20.1 Gradle build passed.
- Covered shared-source setup, compilation, shadowing, source artifacts, remapping, and packaging.
- Inspected compiled bytecode to confirm the wrapper descriptor, target invocation, and exception cleanup path.
- There are no JCM test sources for this path.
- No runtime FPS or TPS benchmark is claimed by this pull request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)